### PR TITLE
Add PRE_CREATE_TOPIC callback to modify topic attributes from outside

### DIFF
--- a/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
+++ b/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
@@ -278,7 +278,7 @@ public:
 private:
     std::shared_ptr<FastDDSTopic> create_topic(
         std::shared_ptr<FastDDSParticipant>& participant,
-        fastrtps::TopicAttributes& attrs);
+        const fastrtps::TopicAttributes& attrs);
 
     std::shared_ptr<FastDDSRequester> create_requester(
         std::shared_ptr<FastDDSParticipant>& participant,

--- a/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
+++ b/include/uxr/agent/middleware/fastdds/FastDDSMiddleware.hpp
@@ -276,6 +276,10 @@ public:
             uint16_t replier_id,
             const dds::xrce::OBJK_Replier_Binary& replier_xrce) const override;
 private:
+    std::shared_ptr<FastDDSTopic> create_topic(
+        std::shared_ptr<FastDDSParticipant>& participant,
+        fastrtps::TopicAttributes& attrs);
+
     std::shared_ptr<FastDDSRequester> create_requester(
         std::shared_ptr<FastDDSParticipant>& participant,
         const fastrtps::RequesterAttributes& attrs);

--- a/include/uxr/agent/middleware/utils/Callbacks.hpp
+++ b/include/uxr/agent/middleware/utils/Callbacks.hpp
@@ -679,7 +679,7 @@ private:
                     fastrtps::TopicAttributes* attrs = va_arg(args, fastrtps::TopicAttributes*);
                     for (const auto& pre_create_topic_callback : pre_create_topic_callbacks_)
                     {
-                        pre_create_topic_callback(participant, *attrs);
+                        pre_create_topic_callback(participant, attrs);
                     }
                     break;
                 }
@@ -695,7 +695,7 @@ private:
                         const fastdds::dds::DomainParticipant*>;
         using CreateTopicCallback = Callback<
                         const fastdds::dds::DomainParticipant*,
-                        fastrtps::TopicAttributes&>;
+                        fastrtps::TopicAttributes*>;
         using CreateDataWriterCallback = Callback<
                         const fastdds::dds::DomainParticipant*,
                         const fastdds::dds::DataWriter*>;
@@ -1019,10 +1019,10 @@ inline void CallbackFactory::FastDDSCallbackFactory::add_callback<
 template <>
 inline void CallbackFactory::FastDDSCallbackFactory::add_callback<
     const fastdds::dds::DomainParticipant*,
-    fastrtps::TopicAttributes&>(
+    fastrtps::TopicAttributes*>(
         const CallbackKind& callback_kind,
         std::function<void (const fastdds::dds::DomainParticipant*,
-                            fastrtps::TopicAttributes&)>&& callback_function)
+                            fastrtps::TopicAttributes*)>&& callback_function)
 {
     switch (callback_kind)
     {
@@ -1030,7 +1030,7 @@ inline void CallbackFactory::FastDDSCallbackFactory::add_callback<
         {
             pre_create_topic_callbacks_.emplace_back(Callback<
                 const fastdds::dds::DomainParticipant*,
-                fastrtps::TopicAttributes&>(std::move(callback_function)));
+                fastrtps::TopicAttributes*>(std::move(callback_function)));
             break;
         }
         default:
@@ -1103,7 +1103,7 @@ CALLBACK_FACTORY_ADD_FASTDDS_CALLBACK(
 
 CALLBACK_FACTORY_ADD_FASTDDS_CALLBACK(
     const fastdds::dds::DomainParticipant*,
-    fastrtps::TopicAttributes&)
+    fastrtps::TopicAttributes*)
 #endif  // UAGENT_FAST_PROFILE
 
 } // namespace middleware

--- a/src/cpp/Agent.cpp
+++ b/src/cpp/Agent.cpp
@@ -18,6 +18,10 @@
 #include <uxr/agent/datawriter/DataWriter.hpp>
 #include <uxr/agent/middleware/utils/Callbacks.hpp>
 
+#ifdef UAGENT_FAST_PROFILE
+#include <fastrtps/attributes/TopicAttributes.h>
+#endif
+
 namespace eprosima {
 namespace uxr {
 
@@ -688,6 +692,10 @@ AGENT_ADD_MW_CB(
     const eprosima::fastdds::dds::DomainParticipant *,
     const eprosima::fastdds::dds::DataWriter *,
     const eprosima::fastdds::dds::DataReader *)
+
+AGENT_ADD_MW_CB(
+    eprosima::fastrtps::TopicAttributes&)
+
 #endif  // UAGENT_FAST_PROFILE
 
 } // namespace uxr

--- a/src/cpp/Agent.cpp
+++ b/src/cpp/Agent.cpp
@@ -694,6 +694,7 @@ AGENT_ADD_MW_CB(
     const eprosima::fastdds::dds::DataReader *)
 
 AGENT_ADD_MW_CB(
+    const eprosima::fastdds::dds::DomainParticipant *,
     eprosima::fastrtps::TopicAttributes&)
 
 #endif  // UAGENT_FAST_PROFILE

--- a/src/cpp/Agent.cpp
+++ b/src/cpp/Agent.cpp
@@ -695,7 +695,7 @@ AGENT_ADD_MW_CB(
 
 AGENT_ADD_MW_CB(
     const eprosima::fastdds::dds::DomainParticipant *,
-    eprosima::fastrtps::TopicAttributes&)
+    eprosima::fastrtps::TopicAttributes*)
 
 #endif  // UAGENT_FAST_PROFILE
 

--- a/src/cpp/AgentInstance.cpp
+++ b/src/cpp/AgentInstance.cpp
@@ -170,6 +170,9 @@ AGENTINSTANCE_ADD_MW_CB(
     const eprosima::fastdds::dds::DomainParticipant *,
     const eprosima::fastdds::dds::DataWriter *,
     const eprosima::fastdds::dds::DataReader *)
+
+AGENTINSTANCE_ADD_MW_CB(
+    eprosima::fastrtps::TopicAttributes&)
 #endif  // UAGENT_FAST_PROFILE
 
 } // namespace uxr

--- a/src/cpp/AgentInstance.cpp
+++ b/src/cpp/AgentInstance.cpp
@@ -172,6 +172,7 @@ AGENTINSTANCE_ADD_MW_CB(
     const eprosima::fastdds::dds::DataReader *)
 
 AGENTINSTANCE_ADD_MW_CB(
+    const eprosima::fastdds::dds::DomainParticipant *,
     eprosima::fastrtps::TopicAttributes&)
 #endif  // UAGENT_FAST_PROFILE
 

--- a/src/cpp/AgentInstance.cpp
+++ b/src/cpp/AgentInstance.cpp
@@ -173,7 +173,7 @@ AGENTINSTANCE_ADD_MW_CB(
 
 AGENTINSTANCE_ADD_MW_CB(
     const eprosima::fastdds::dds::DomainParticipant *,
-    eprosima::fastrtps::TopicAttributes&)
+    eprosima::fastrtps::TopicAttributes*)
 #endif  // UAGENT_FAST_PROFILE
 
 } // namespace uxr

--- a/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
+++ b/src/cpp/middleware/fastdds/FastDDSMiddleware.cpp
@@ -158,11 +158,14 @@ bool FastDDSMiddleware::create_participant_by_bin(
     return rv;
 }
 
-static
-std::shared_ptr<FastDDSTopic> create_topic(
+std::shared_ptr<FastDDSTopic> FastDDSMiddleware::create_topic(
         std::shared_ptr<FastDDSParticipant>& participant,
-        const fastrtps::TopicAttributes& attrs)
+        fastrtps::TopicAttributes& attrs)
 {
+    callback_factory_.execute_callbacks(Middleware::Kind::FASTDDS,
+                    middleware::CallbackKind::CREATE_TOPIC,
+                    &attrs);
+
     std::shared_ptr<FastDDSTopic> topic = participant->find_local_topic(attrs.getTopicName().c_str());
     if (topic)
     {
@@ -502,8 +505,10 @@ std::shared_ptr<FastDDSRequester> FastDDSMiddleware::create_requester(
         const fastrtps::RequesterAttributes& attrs)
 {
     std::shared_ptr<FastDDSRequester> requester{};
-    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, attrs.publisher.topic);
-    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, attrs.subscriber.topic);
+    fastrtps::TopicAttributes request_topic_attrs = attrs.publisher.topic;
+    fastrtps::TopicAttributes reply_topic_attrs = attrs.subscriber.topic;
+    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, request_topic_attrs);
+    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, reply_topic_attrs);
     if (request_topic && reply_topic)
     {
         requester =
@@ -634,8 +639,10 @@ std::shared_ptr<FastDDSReplier> FastDDSMiddleware::create_replier(
         const fastrtps::ReplierAttributes& attrs)
 {
     std::shared_ptr<FastDDSReplier> replier{};
-    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, attrs.subscriber.topic);
-    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, attrs.publisher.topic);
+    fastrtps::TopicAttributes request_topic_attrs = attrs.subscriber.topic;
+    fastrtps::TopicAttributes reply_topic_attrs = attrs.publisher.topic;
+    std::shared_ptr<FastDDSTopic> request_topic = create_topic(participant, request_topic_attrs);
+    std::shared_ptr<FastDDSTopic> reply_topic = create_topic(participant, reply_topic_attrs);
     if (request_topic && reply_topic)
     {
         replier =


### PR DESCRIPTION
CREATE_TOPIC callback enables external programs to access and modify topic attributes before a topic is created